### PR TITLE
Add hacker simulation game skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# hacker-sim
+# Hacker Simulator
+
+This is a minimal browser-based hacker simulation game using HTML, Tailwind CSS and JavaScript.
+
+## Running the game
+
+Open `index.html` in a web browser. The terminal interface supports a few simple commands:
+
+- `help` - list available commands
+- `clear` - clear the terminal output
+- `mission` - show a sample mission description
+
+Feel free to extend the command system and add missions for a deeper simulation experience.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hacker Simulation</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-900 text-green-400 font-mono">
+  <div id="app" class="container mx-auto p-4">
+    <div id="terminal" class="bg-black p-4 rounded-md h-64 overflow-y-auto">
+      <div id="terminal-output" class="whitespace-pre-wrap text-green-400 text-sm"></div>
+      <div class="flex">
+        <span class="pr-1">$</span>
+        <input id="terminal-input" class="flex-grow bg-transparent outline-none text-green-400 text-sm" autofocus />
+      </div>
+    </div>
+  </div>
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,6 @@
+import { Terminal } from './terminal.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const terminal = new Terminal();
+  terminal.init();
+});

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -1,0 +1,60 @@
+export class Terminal {
+  constructor() {
+    this.outputEl = document.getElementById('terminal-output');
+    this.inputEl = document.getElementById('terminal-input');
+    this.history = [];
+    this.historyIndex = 0;
+  }
+
+  init() {
+    this.writeLine('Welcome to Hacker Simulator');
+    this.inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        const command = this.inputEl.value.trim();
+        this.history.push(command);
+        this.historyIndex = this.history.length;
+        this.handleCommand(command);
+        this.inputEl.value = '';
+      } else if (e.key === 'ArrowUp') {
+        if (this.historyIndex > 0) {
+          this.historyIndex--;
+          this.inputEl.value = this.history[this.historyIndex];
+        }
+      } else if (e.key === 'ArrowDown') {
+        if (this.historyIndex < this.history.length - 1) {
+          this.historyIndex++;
+          this.inputEl.value = this.history[this.historyIndex];
+        } else {
+          this.historyIndex = this.history.length;
+          this.inputEl.value = '';
+        }
+      }
+    });
+  }
+
+  handleCommand(command) {
+    this.writeLine('$ ' + command);
+    switch (command) {
+      case 'help':
+        this.writeLine('Available commands: help, clear, mission');
+        break;
+      case 'clear':
+        this.clear();
+        break;
+      case 'mission':
+        this.writeLine('Your first mission is to hack the simulated network.');
+        break;
+      default:
+        this.writeLine(`Unknown command: ${command}`);
+    }
+  }
+
+  writeLine(text) {
+    this.outputEl.textContent += text + '\n';
+    this.outputEl.scrollTop = this.outputEl.scrollHeight;
+  }
+
+  clear() {
+    this.outputEl.textContent = '';
+  }
+}


### PR DESCRIPTION
## Summary
- add HTML page with Tailwind and basic terminal interface
- add ES6 modules for terminal logic
- update README with instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862c38dae348327a976ebd3d78de58c